### PR TITLE
get redmine code from github (instead of redmine.org)

### DIFF
--- a/bin/travisci_before_install.sh
+++ b/bin/travisci_before_install.sh
@@ -12,10 +12,11 @@ fi
 # Shelve the plugin files to a temporary directory
 cp -pr . /tmp/${PLUGIN_NAME}
 
-# Get & deploy Redmine
-wget https://www.redmine.org/releases/redmine-${REDMINE_VERSION}.tar.gz
-tar zxf redmine-${REDMINE_VERSION}.tar.gz
-rsync -a redmine-${REDMINE_VERSION}/ redmine/
+# Get Redmine code
+if [ -d redmine ]; then
+  rm -rf redmine
+fi
+git clone -b ${REDMINE_VERSION} --depth=1 https://github.com/redmine/redmine.git
 
 # Restore the cache if exists
 if [ -f /tmp/vendor ]; then

--- a/bin/travisci_before_install.sh
+++ b/bin/travisci_before_install.sh
@@ -5,7 +5,7 @@
 PLUGIN_NAME=redmine_scheduling_poll
 
 # Shelve the cache if exists
-if [ -f redmine/vendor/bundle ]; then
+if [ -d redmine/vendor/bundle ]; then
   mv redmine/vendor /tmp/vendor
 fi
 
@@ -19,7 +19,7 @@ fi
 git clone -b ${REDMINE_VERSION} --depth=1 https://github.com/redmine/redmine.git
 
 # Restore the cache if exists
-if [ -f /tmp/vendor ]; then
+if [ -d /tmp/vendor ]; then
   mv /tmp/vendor redmine/vendor
 fi
 


### PR DESCRIPTION
For travis-CI, switch the redmine download source from redmine.org to github tag.