### PR TITLE
Show poll-related actions on the activity page

### DIFF
--- a/app/models/scheduling_poll.rb
+++ b/app/models/scheduling_poll.rb
@@ -16,7 +16,6 @@ class SchedulingPoll < ActiveRecord::Base
                 :description => nil,
                 :datetime => :created_at,
                 :author => nil,
-                :group => :issue,
                 :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.id } }
 
   acts_as_activity_provider :type => "scheduling_poll",

--- a/app/models/scheduling_poll.rb
+++ b/app/models/scheduling_poll.rb
@@ -8,7 +8,22 @@ class SchedulingPoll < ActiveRecord::Base
   has_many :votes, :through => :scheduling_poll_items, :source => :scheduling_votes
   has_many :users, lambda { order(:id).distinct }, :through => :scheduling_poll_items
 
+  delegate :project, :to => :issue
+
   validates :issue, :presence => true
+
+  acts_as_event :title => Proc.new { |o| "#{l(:label_scheduling_poll)}: #{o.issue}" },
+                :description => nil,
+                :datetime => :created_at,
+                :author => nil,
+                :group => :issue,
+                :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.id } }
+
+  acts_as_activity_provider :type => "scheduling_poll",
+                            :timestamp => :created_at,
+                            :permission => :view_schduling_polls,
+                            :author_key => nil,
+                            :scope =>joins(:issue => :project)
 
   def votes_by_user(user)
     self.votes.where(:user => user)

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -11,6 +11,8 @@ class SchedulingPollItem < ActiveRecord::Base
   validates :scheduling_poll, :presence => true
   validates :text, :presence => true, :allow_blank => false
 
+  delegate :project, :to => :scheduling_poll
+
   def vote_by_user(user)
     self.scheduling_votes.find_by(:user => user)
   end

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -26,9 +26,9 @@ class SchedulingPollItem < ActiveRecord::Base
     v = self.vote_by_user(user)
     unless value == 0
       if v.nil?
-        v = self.scheduling_votes.create(:user => user, :value => value, :create_at => Time.now)
+        v = self.scheduling_votes.create(:user => user, :value => value)
       else
-        v.update(:value => value, :modify_at => Time.now)
+        v.update(:value => value)
       end
     else # remove vote
       v.destroy unless v.nil?

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -19,7 +19,7 @@ class SchedulingPollItem < ActiveRecord::Base
                             :timestamp => "COALESCE(#{table_name}.updated_at, #{table_name}.created_at)",
                             :permission => :view_schduling_polls,
                             :author_key => nil,
-                            :scope =>joins(:scheduling_poll => {:issue => :project})
+                            :scope =>where("COALESCE(#{table_name}.updated_at, #{table_name}.created_at) IS NOT NULL").joins(:scheduling_poll => {:issue => :project})
 
   validates :scheduling_poll, :presence => true
   validates :text, :presence => true, :allow_blank => false

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -8,6 +8,19 @@ class SchedulingPollItem < ActiveRecord::Base
 
   scope :sorted, lambda { order(:position => :asc) }
 
+  acts_as_event :title => Proc.new { |o| "#{l(:label_scheduling_poll)}: #{o.scheduling_poll.issue}" },
+                :description => Proc.new { |o| "#{l(:label_scheduling_poll_item)}: #{o.text}" },
+                :datetime => Proc.new { |o| o.updated_at || o.created_at },
+                :author => nil,
+                :group => :scheduling_poll,
+                :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.scheduling_poll.id } }
+
+  acts_as_activity_provider :type => "scheduling_poll_item",
+                            :timestamp => "COALESCE(#{table_name}.updated_at, #{table_name}.created_at)",
+                            :permission => :view_schduling_polls,
+                            :author_key => nil,
+                            :scope =>joins(:scheduling_poll => {:issue => :project})
+
   validates :scheduling_poll, :presence => true
   validates :text, :presence => true, :allow_blank => false
 

--- a/app/models/scheduling_vote.rb
+++ b/app/models/scheduling_vote.rb
@@ -10,13 +10,13 @@ class SchedulingVote < ActiveRecord::Base
 
   acts_as_event :title => Proc.new { |o| "#{l(:label_scheduling_poll)}: #{o.scheduling_poll_item.scheduling_poll.issue}" },
                 :description => Proc.new { |o| "#{l(:label_vote_on_scheduling_poll)}: #{o.scheduling_poll_item.text}: #{SchedulingPollsController.helpers.scheduling_vote_value(o.value)}" },
-                :datetime => Proc.new { |o| o.modify_at || o.create_at },
+                :datetime => Proc.new { |o| o.updated_at || o.created_at },
                 :author => Proc.new { |o| o.user },
                 :group => :scheduling_poll,
                 :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.scheduling_poll_item.scheduling_poll.id } }
 
   acts_as_activity_provider :type => "scheduling_vote",
-                            :timestamp => "COALESCE(#{table_name}.modify_at, #{table_name}.create_at)",
+                            :timestamp => "COALESCE(#{table_name}.updated_at, #{table_name}.created_at)",
                             :permission => :view_schduling_polls,
                             :author_key => :user_id,
                             :scope =>joins(:scheduling_poll_item => {:scheduling_poll => {:issue => :project}})

--- a/app/models/scheduling_vote.rb
+++ b/app/models/scheduling_vote.rb
@@ -10,13 +10,13 @@ class SchedulingVote < ActiveRecord::Base
 
   acts_as_event :title => Proc.new { |o| "#{l(:label_scheduling_poll)}: #{o.scheduling_poll_item.scheduling_poll.issue}" },
                 :description => Proc.new { |o| "#{l(:label_vote_on_scheduling_poll)}: #{o.scheduling_poll_item.text}: #{SchedulingPollsController.helpers.scheduling_vote_value(o.value)}" },
-                :datetime => :modify_at,
+                :datetime => Proc.new { |o| o.modify_at || o.create_at },
                 :author => Proc.new { |o| o.user },
                 :group => :scheduling_poll,
                 :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.scheduling_poll_item.scheduling_poll.id } }
 
   acts_as_activity_provider :type => "scheduling_vote",
-                            :timestamp => :modify_at,
+                            :timestamp => "COALESCE(#{table_name}.modify_at, #{table_name}.create_at)",
                             :permission => :view_schduling_polls,
                             :author_key => :user_id,
                             :scope =>joins(:scheduling_poll_item => {:scheduling_poll => {:issue => :project}})

--- a/app/models/scheduling_vote.rb
+++ b/app/models/scheduling_vote.rb
@@ -5,6 +5,22 @@ class SchedulingVote < ActiveRecord::Base
   belongs_to :user
   belongs_to :scheduling_poll_item
 
+  delegate :project, :to => :scheduling_poll_item
+  delegate :scheduling_poll, :to => :scheduling_poll_item
+
+  acts_as_event :title => Proc.new { |o| "#{l(:label_scheduling_poll)}: #{o.scheduling_poll_item.scheduling_poll.issue}" },
+                :description => Proc.new { |o| "#{l(:label_vote_on_scheduling_poll)}: #{o.scheduling_poll_item.text}: #{SchedulingPollsController.helpers.scheduling_vote_value(o.value)}" },
+                :datetime => :modify_at,
+                :author => Proc.new { |o| o.user },
+                :group => :scheduling_poll,
+                :url => Proc.new { |o| {:controller => 'scheduling_polls', :action => 'show', :id => o.scheduling_poll_item.scheduling_poll.id } }
+
+  acts_as_activity_provider :type => "scheduling_vote",
+                            :timestamp => :modify_at,
+                            :permission => :view_schduling_polls,
+                            :author_key => :user_id,
+                            :scope =>joins(:scheduling_poll_item => {:scheduling_poll => {:issue => :project}})
+
   validates :user, :presence => true
   validates :scheduling_poll_item, :presence => true
   validates :value, :numericality => { :greater_than => 0 }, :presence => true

--- a/app/views/scheduling_polls/show.api.rsb
+++ b/app/views/scheduling_polls/show.api.rsb
@@ -10,8 +10,8 @@ api.scheduling_poll do
             api.scheduling_vote do
               api.user :id => vote.user.id, :name => vote.user.name
               api.value :value => vote.value, :text => scheduling_vote_value(vote.value)
-              api.create_at vote.create_at if vote.create_at
-              api.modify_at vote.modify_at if vote.modify_at
+              api.created_at vote.created_at if vote.created_at
+              api.updated_at vote.updated_at if vote.updated_at
             end
           end
         end

--- a/app/views/scheduling_polls/show.api.rsb
+++ b/app/views/scheduling_polls/show.api.rsb
@@ -5,6 +5,8 @@ api.scheduling_poll do
   api.array :scheduling_poll_items do
     @poll.scheduling_poll_items.sorted.each do |item|
       api.scheduling_poll_item :id => item.id, :text => item.text do
+        api.created_at item.created_at if item.created_at
+        api.updated_at item.updated_at if item.updated_at
         api.array :scheduling_votes do
           item.scheduling_votes.each do |vote|
             api.scheduling_vote do

--- a/app/views/scheduling_polls/show.html.erb
+++ b/app/views/scheduling_polls/show.html.erb
@@ -107,7 +107,7 @@ EOD
       <% @poll.scheduling_poll_items.sorted.each do |item| %>
         <% vote = item.vote_by_user(user) %>
         <% if vote %>
-          <%= content_tag :td, scheduling_vote_value(vote), :title => format_time(vote.modify_at || vote.create_at) %>
+          <%= content_tag :td, scheduling_vote_value(vote), :title => format_time(vote.updated_at || vote.created_at) %>
         <% else %>
           <%= content_tag :td %>
         <% end %>
@@ -129,7 +129,7 @@ EOD
 </table>
 </div>
 <ul>
-<% datetime = Arel::Nodes::NamedFunction.new('COALESCE', [SchedulingVote.arel_table[:modify_at], SchedulingVote.arel_table[:create_at]]) %>
+<% datetime = Arel::Nodes::NamedFunction.new('COALESCE', [SchedulingVote.arel_table[:updated_at], SchedulingVote.arel_table[:created_at]]) %>
 <% @poll.votes.group(:user).maximum(datetime.to_sql).sort_by { |k,v| v }.each do |v| %>
   <% user, datetime = v %>
   <li>

--- a/app/views/scheduling_polls/show.html.erb
+++ b/app/views/scheduling_polls/show.html.erb
@@ -128,14 +128,23 @@ EOD
   </tfoot>
 </table>
 </div>
-<ul>
-<% datetime = Arel::Nodes::NamedFunction.new('COALESCE', [SchedulingVote.arel_table[:updated_at], SchedulingVote.arel_table[:created_at]]) %>
-<% @poll.votes.group(:user).maximum(datetime.to_sql).sort_by { |k,v| v }.each do |v| %>
-  <% user, datetime = v %>
-  <li>
-    <%= avatar(user, :size => "24") %>
-    <%= authoring datetime, user, :label => :label_updated_time_by %>
-  </li>
+
+<ul class="scheduling-voting-result-timeline">
+<% ((@poll.votes.group(:user).maximum("COALESCE(scheduling_votes.updated_at, scheduling_votes.created_at)").to_a) +
+    (@poll.scheduling_poll_items.map{|v| [v, v.updated_at || v.created_at]} )).reject{|v| v[1].nil? }.sort{|a,b| a[1] <=> b[1]}.each do |v| %>
+  <% subject, datetime = v %>
+  <% if subject.kind_of? User
+     user = subject %>
+    <li>
+      <%= avatar(user, :size => "24") %>
+      <%= authoring datetime, user, :label => :label_updated_time_by %>
+    </li>
+  <% elsif subject.kind_of? SchedulingPollItem %>
+    <li class="scheduling-poll-item-update">
+      <%= l(:label_scheduling_poll_item) %> "<%=h subject.text %>":
+      <%= l(:label_updated_time, :value => time_tag(datetime)).html_safe %>
+    </li>
+  <% end %>
 <% end %>
 </ul>
 <% else %><%# if @poll.scheduling_poll_items.empty? %>

--- a/assets/stylesheets/scheduling_polls.css
+++ b/assets/stylesheets/scheduling_polls.css
@@ -8,6 +8,10 @@
     background-color: #FFD;
 }
 
+.scheduling-voting-result-timeline .scheduling-poll-item-update {
+    color: #888;
+}
+
 @media all and (max-width: 899px) {
     .scheduling-poll-vote-result-side-col {
         display: none;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,9 @@ en:
   permission_vote_schduling_polls: Vote on scheduling polls
   label_scheduling_poll: Scheduling poll
   label_scheduling_poll_plural: Scheduling polls
-  label_scheduling_vote_plural: Votes
+  label_scheduling_poll_item: Item of scheduling poll
+  label_scheduling_poll_item_plural: Items of scheduling polls
+  label_scheduling_vote_plural: Votes on scheduling polls
   label_edit_scheduling_poll_items: Edit poll items
   label_add_comment_with_scheduling_poll_vote: Add a comment
   label_vote_on_scheduling_poll: Vote

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
   permission_vote_schduling_polls: Vote on scheduling polls
   label_scheduling_poll: Scheduling poll
   label_scheduling_poll_plural: Scheduling polls
+  label_scheduling_vote_plural: Votes
   label_edit_scheduling_poll_items: Edit poll items
   label_add_comment_with_scheduling_poll_vote: Add a comment
   label_vote_on_scheduling_poll: Vote

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   permission_view_schduling_polls: View scheduling polls
   permission_vote_schduling_polls: Vote on scheduling polls
   label_scheduling_poll: Scheduling poll
+  label_scheduling_poll_plural: Scheduling polls
   label_edit_scheduling_poll_items: Edit poll items
   label_add_comment_with_scheduling_poll_vote: Add a comment
   label_vote_on_scheduling_poll: Vote

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,7 +5,9 @@ fr:
   permission_vote_schduling_polls: Voter aux sondages
   label_scheduling_poll: Sondage
   label_scheduling_poll_plural: Sondages
-  label_scheduling_vote_plural: Voter
+  label_scheduling_poll_item: Choix du sondage
+  label_scheduling_poll_item_plural: Choix du sondage
+  label_scheduling_vote_plural: Voter aux sondages
   label_edit_scheduling_poll_items: Edition des choix du sondage
   label_add_comment_with_scheduling_poll_vote: Ajouter un commentaire
   label_vote_on_scheduling_poll: Voter

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,6 +4,7 @@ fr:
   permission_view_schduling_polls: Visualiser les sondages
   permission_vote_schduling_polls: Voter aux sondages
   label_scheduling_poll: Sondage
+  label_scheduling_poll_plural: Sondages
   label_edit_scheduling_poll_items: Edition des choix du sondage
   label_add_comment_with_scheduling_poll_vote: Ajouter un commentaire
   label_vote_on_scheduling_poll: Voter

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -5,6 +5,7 @@ fr:
   permission_vote_schduling_polls: Voter aux sondages
   label_scheduling_poll: Sondage
   label_scheduling_poll_plural: Sondages
+  label_scheduling_vote_plural: Voter
   label_edit_scheduling_poll_items: Edition des choix du sondage
   label_add_comment_with_scheduling_poll_vote: Ajouter un commentaire
   label_vote_on_scheduling_poll: Voter

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
   permission_view_schduling_polls: スケジュール調整の表示
   permission_vote_schduling_polls: スケジュール調整への回答
   label_scheduling_poll: スケジュール調整
+  label_scheduling_poll_plural: スケジュール調整
   label_edit_scheduling_poll_items: 回答項目の編集
   label_add_comment_with_scheduling_poll_vote: コメントを追記
   label_vote_on_scheduling_poll: 回答

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
   permission_vote_schduling_polls: スケジュール調整への回答
   label_scheduling_poll: スケジュール調整
   label_scheduling_poll_plural: スケジュール調整
+  label_scheduling_vote_plural: 回答
   label_edit_scheduling_poll_items: 回答項目の編集
   label_add_comment_with_scheduling_poll_vote: コメントを追記
   label_vote_on_scheduling_poll: 回答

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,7 +4,9 @@ ja:
   permission_vote_schduling_polls: スケジュール調整への回答
   label_scheduling_poll: スケジュール調整
   label_scheduling_poll_plural: スケジュール調整
-  label_scheduling_vote_plural: 回答
+  label_scheduling_poll_item: スケジュール調整の項目
+  label_scheduling_poll_item_plural: スケジュール調整の項目
+  label_scheduling_vote_plural: スケジュール調整への回答
   label_edit_scheduling_poll_items: 回答項目の編集
   label_add_comment_with_scheduling_poll_vote: コメントを追記
   label_vote_on_scheduling_poll: 回答

--- a/db/migrate/004_add_timestamp_to_scheduling_poll_items_and_fix_timestamp_of_scheduling_votes.rb
+++ b/db/migrate/004_add_timestamp_to_scheduling_poll_items_and_fix_timestamp_of_scheduling_votes.rb
@@ -1,0 +1,10 @@
+class AddTimestampToSchedulingPollItemsAndFixTimestampOfSchedulingVotes < ActiveRecord::Migration
+  def change
+    change_table :scheduling_poll_items do |t|
+      t.timestamps
+    end
+
+    rename_column :scheduling_votes, :create_at, :created_at
+    rename_column :scheduling_votes, :modify_at, :updated_at
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -16,6 +16,7 @@ Redmine::Plugin.register :redmine_scheduling_poll do
   end
   Redmine::Activity.map do |activity|
     activity.register(:scheduling_poll)
+    activity.register(:scheduling_poll_item)
     activity.register(:scheduling_vote)
   end
 

--- a/init.rb
+++ b/init.rb
@@ -14,6 +14,9 @@ Redmine::Plugin.register :redmine_scheduling_poll do
     permission :view_schduling_polls, :polls => [:show, :show_by_issue]
     permission :vote_schduling_polls, :polls => [:new, :create, :edit, :update, :vote]
   end
+  Redmine::Activity.map do |activity|
+    activity.register(:scheduling_poll)
+  end
 
   settings :default => {
     'scheduling_vote_value_5' => '',

--- a/init.rb
+++ b/init.rb
@@ -16,6 +16,7 @@ Redmine::Plugin.register :redmine_scheduling_poll do
   end
   Redmine::Activity.map do |activity|
     activity.register(:scheduling_poll)
+    activity.register(:scheduling_vote)
   end
 
   settings :default => {

--- a/test/fixtures/scheduling_poll_items.yml
+++ b/test/fixtures/scheduling_poll_items.yml
@@ -5,12 +5,14 @@ scheduling_poll_item_001:
   position: 1
   text: scheduling_poll_item_001
   created_at: <%= 50.seconds.ago %>
+  updated_at: null
 scheduling_poll_item_002:
   id: 2
   scheduling_poll_id: 1
   position: 2
   text: scheduling_poll_item_002
   created_at: <%= 50.seconds.ago %>
+  updated_at: null
 scheduling_poll_item_003:
   id: 3
   scheduling_poll_id: 1
@@ -23,13 +25,19 @@ scheduling_poll_item_004:
   scheduling_poll_id: 2
   position: 3
   text: scheduling_poll_item_004
+  created_at: null
+  updated_at: null
 scheduling_poll_item_005:
   id: 5
   scheduling_poll_id: 2
   position: 2
   text: scheduling_poll_item_005
+  created_at: null
+  updated_at: null
 scheduling_poll_item_006:
   id: 6
   scheduling_poll_id: 2
   position: 1
   text: scheduling_poll_item_006
+  created_at: null
+  updated_at: null

--- a/test/fixtures/scheduling_poll_items.yml
+++ b/test/fixtures/scheduling_poll_items.yml
@@ -4,16 +4,20 @@ scheduling_poll_item_001:
   scheduling_poll_id: 1
   position: 1
   text: scheduling_poll_item_001
+  created_at: <%= 50.seconds.ago %>
 scheduling_poll_item_002:
   id: 2
   scheduling_poll_id: 1
   position: 2
   text: scheduling_poll_item_002
+  created_at: <%= 50.seconds.ago %>
 scheduling_poll_item_003:
   id: 3
   scheduling_poll_id: 1
   position: 3
   text: scheduling_poll_item_003
+  created_at: <%= 50.seconds.ago %>
+  updated_at: <%= 30.seconds.ago %>
 scheduling_poll_item_004:
   id: 4
   scheduling_poll_id: 2

--- a/test/fixtures/scheduling_votes.yml
+++ b/test/fixtures/scheduling_votes.yml
@@ -4,40 +4,40 @@ scheduling_vote_001:
   user_id: 1
   scheduling_poll_item_id: 1
   value: 3
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_002:
   id: 2
   user_id: 1
   scheduling_poll_item_id: 2
   value: 3
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_003:
   id: 3
   user_id: 1
   scheduling_poll_item_id: 3
   value: 3
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_004:
   id: 4
   user_id: 2
   scheduling_poll_item_id: 1
   value: 2
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_005:
   id: 5
   user_id: 2
   scheduling_poll_item_id: 2
   value: 3
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_006:
   id: 6
   user_id: 2
   scheduling_poll_item_id: 3
   value: 4
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>
 scheduling_vote_007:
   id: 7
   user_id: 3
   scheduling_poll_item_id: 1
   value: 1
-  create_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago.to_s(:db) %>

--- a/test/unit/scheduling_vote_test.rb
+++ b/test/unit/scheduling_vote_test.rb
@@ -2,7 +2,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class SchedulingVoteTest < ActiveSupport::TestCase
-  fixtures :issues, :users, :scheduling_polls, :scheduling_poll_items, :scheduling_votes
+  fixtures :projects, :issues, :roles, :users, :scheduling_polls, :scheduling_poll_items, :scheduling_votes
 
   test "shall not save scheduling vote without user" do
     scheduling_vote = SchedulingVote.new
@@ -50,5 +50,17 @@ class SchedulingVoteTest < ActiveSupport::TestCase
     assert scheduling_vote.save
 
     assert scheduling_vote.destroy
+  end
+
+  test "activity fetcher shall be return based on :created_at" do
+    Project.find(1).enable_module! :scheduling_polls
+    Role.all.each do |role|
+      role.add_permission! :view_schduling_polls
+    end
+    fetcher = Redmine::Activity::Fetcher.new(User.find(2))
+    fetcher.scope = %w[scheduling_vote]
+
+    expected = SchedulingVote.all.sort {|a,b| b.created_at <=> a.created_at }
+    assert_equal expected, fetcher.events(1.day.ago, Date.today + 1)
   end
 end


### PR DESCRIPTION
Show poll-related actions on activity page: creating a poll, adding a poll item, voting.

DB shall be updated: to add timestamp to `SchedulingPollItem`.