### PR TITLE
manually specify `null: true` to t.timestamps on the migration script

### DIFF
--- a/db/migrate/004_add_timestamp_to_scheduling_poll_items_and_fix_timestamp_of_scheduling_votes.rb
+++ b/db/migrate/004_add_timestamp_to_scheduling_poll_items_and_fix_timestamp_of_scheduling_votes.rb
@@ -1,7 +1,7 @@
 class AddTimestampToSchedulingPollItemsAndFixTimestampOfSchedulingVotes < ActiveRecord::Migration
   def change
     change_table :scheduling_poll_items do |t|
-      t.timestamps
+      t.timestamps :null => true
     end
 
     rename_column :scheduling_votes, :create_at, :created_at


### PR DESCRIPTION
In Rails 5, this behavior will change to `null: false`. This change prevents the behavior of the existing migrations from changing.