### PR TITLE
WIP: fix UI <div> bug again

### DIFF
--- a/app/views/hooks/redmine_scheduling_poll/_view_issues_show_description_bottom.erb
+++ b/app/views/hooks/redmine_scheduling_poll/_view_issues_show_description_bottom.erb
@@ -1,8 +1,8 @@
 <%# frozen_string_literal: true %>
 <% if @project.module_enabled?(:scheduling_polls) %>
 <hr />
-<% if User.current.allowed_to?(:view_schduling_polls, @project) %>
 <div class="scheduling_poll">
+<% if User.current.allowed_to?(:view_schduling_polls, @project) %>
 <% scheduling_poll = SchedulingPoll.find_by(:issue => @issue) %>
 <% if scheduling_poll %>
 <% vote_values = Hash[*SchedulingPollsController.helpers.scheduling_vote_values_array.flatten] %>
@@ -52,9 +52,9 @@
   </div>
   <p><strong><%=h l :label_scheduling_poll %></strong></p>
 <% end %>
-</div>
 <% else %>
   <p><strong><%=h l :label_scheduling_poll %></strong></p>
 <% end %>
+</div>
 
 <% end %><%# @project.module_enabled?(:scheduling_polls) %>


### PR DESCRIPTION
#31, #32 is not enough.

If permission "View scheduling polls" enabled and a scheduling poll not created for the issue, the `</div>` tag is omitted.
