### PR TITLE
Support for Redmine6 (Rails7)

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,15 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
-        - '3.3 redmica/redmica@v3.0.1'
+        - '3.3 redmica/redmica@v3.1.0'
+        - '3.3 redmica/redmica@v3.0.4'
         - '3.2 redmica/redmica@v2.4.2'
         - '3.2 redmica/redmica@v2.3.2'
         - '3.1 redmica/redmica@v2.2.3'
         - '3.0 redmica/redmica@v2.2.3'
         - '2.7 redmica/redmica@v2.2.3'
-        - '3.2 redmine/redmine@5.1.3'
-        - '3.1 redmine/redmine@5.0.9'
-        - '3.0 redmine/redmine@5.0.9'
+        - '3.3 redmine/redmine@6.0.1'
+        - '3.2 redmine/redmine@5.1.4'
+        - '3.1 redmine/redmine@5.0.10'
+        - '3.0 redmine/redmine@5.0.10'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
         experimental: [false]

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -22,9 +22,6 @@ jobs:
         - '3.0 redmine/redmine@5.0.9'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
-        - '2.6 redmine/redmine@4.1.7'
-        - '2.6 redmine/redmine@4.0.9'
-        - '2.5 redmine/redmine@4.0.9'
         experimental: [false]
         include:
           - mat_env: '3.3 redmica/redmica@master'
@@ -73,13 +70,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: uninitialized constant Nokogiri::HTML4 Issue HACK ref. https://qiita.com/Mattani/items/c4bcc95a72b69d1c0489
-      uses: DamianReeves/write-file-action@v1.2
-      with:
-        path: ./redmine/Gemfile.local
-        contents: |
-          gem 'loofah', '~> 2.20.0'
-      if: contains(fromJSON('["2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9"]'), matrix.mat_env)
     - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
       uses: DamianReeves/write-file-action@v1.2
       with:

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,13 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
+        - '3.3 redmica/redmica@v3.0.1'
+        - '3.2 redmica/redmica@v2.4.2'
         - '3.2 redmica/redmica@v2.3.2'
         - '3.1 redmica/redmica@v2.2.3'
         - '3.0 redmica/redmica@v2.2.3'
         - '2.7 redmica/redmica@v2.2.3'
-        - '3.2 redmine/redmine@5.1.0'
-        - '3.1 redmine/redmine@5.0.6'
-        - '3.0 redmine/redmine@5.0.6'
+        - '3.2 redmine/redmine@5.1.3'
+        - '3.1 redmine/redmine@5.0.9'
+        - '3.0 redmine/redmine@5.0.9'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.1.7'
@@ -25,7 +27,7 @@ jobs:
         - '2.5 redmine/redmine@4.0.9'
         experimental: [false]
         include:
-          - mat_env: '3.2 redmica/redmica@master'
+          - mat_env: '3.3 redmica/redmica@master'
             experimental: true
     steps:
     - run: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -80,6 +80,13 @@ jobs:
         contents: |
           gem 'loofah', '~> 2.20.0'
       if: contains(fromJSON('["2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9"]'), matrix.mat_env)
+    - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
+      uses: DamianReeves/write-file-action@v1.2
+      with:
+        path: ./redmine/Gemfile.local
+        contents: |
+          gem 'builder', '~> 3.2.4'
+      if: contains(fromJSON('["3.2 redmica/redmica@v2.4.2", "3.2 redmica/redmica@v2.3.2", "3.1 redmica/redmica@v2.2.3", "3.0 redmica/redmica@v2.2.3", "2.7 redmica/redmica@v2.2.3", "2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9", "2.6 redmine/redmine@4.2.11", "2.7 redmine/redmine@4.2.11"]'), matrix.mat_env)
 
     - name: Before script
       run: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -42,11 +42,11 @@ jobs:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ./${{ env.PLUGIN_NAME }}
     - name: Set up Redmine
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REDMINE_REPOSITORY }}
         ref: ${{ env.REDMINE_REF }}
@@ -55,7 +55,7 @@ jobs:
     - name: Copy the plugin files to plugin directory
       run: cp -pr ./${{ env.PLUGIN_NAME }} ./redmine/plugins/${{ env.PLUGIN_NAME }}
     - name: Create redmine/config/database.yml
-      uses: DamianReeves/write-file-action@v1.2
+      uses: DamianReeves/write-file-action@v1.3
       with:
         path: ./redmine/config/database.yml
         contents: |
@@ -63,7 +63,7 @@ jobs:
             adapter: sqlite3
             database: db/redmine_test.db
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ./redmine/vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('./redmine/**/Gemfile.lock') }}
@@ -71,7 +71,7 @@ jobs:
           ${{ runner.os }}-gems-
 
     - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
-      uses: DamianReeves/write-file-action@v1.2
+      uses: DamianReeves/write-file-action@v1.3
       with:
         path: ./redmine/Gemfile.local
         contents: |

--- a/README.rdoc
+++ b/README.rdoc
@@ -24,6 +24,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/cat-in
 
 == License
 
-MIT License.
-See the 'LICENSE.md' file.
+* Codes: MIT License.
+* Legacy Icons: famfamfam-silk: {CC-By-2.5}[https://creativecommons.org/licenses/by/2.5/] by Mark James http://www.famfamfam.com/lab/icons/silk/
+* Vector Icons: {Tabler Icons}[https://tabler.io/]: MIT License
 

--- a/app/controllers/scheduling_polls_controller.rb
+++ b/app/controllers/scheduling_polls_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SchedulingPollsController < ApplicationController
-  unloadable
+  unloadable if respond_to?(:unloadable)
 
   before_action :set_scheduling_poll, :only => [:edit, :update, :show, :vote]
   before_action :set_scheduling_poll_by_issue_id, :only => [:show_by_issue]

--- a/app/helpers/scheduling_polls_helper.rb
+++ b/app/helpers/scheduling_polls_helper.rb
@@ -46,7 +46,7 @@ module SchedulingPollsHelper
     s.html_safe
   end
 
-  if defined? IconsHelper # redmine >= 7.0
+  if defined? IconsHelper # redmine >= 6.0
     include IconsHelper
     def scheduling_icon_with_label(icon_name, label_text, icon_only: false, size: 18, css_class: nil)
       label_classes = ["icon-label"]

--- a/app/helpers/scheduling_polls_helper.rb
+++ b/app/helpers/scheduling_polls_helper.rb
@@ -46,4 +46,14 @@ module SchedulingPollsHelper
     s.html_safe
   end
 
+  if defined? IconsHelper # redmine >= 7.0
+    include IconsHelper
+    def scheduling_icon_with_label(icon_name, label_text, icon_only: false, size: 18, css_class: nil)
+      label_classes = ["icon-label"]
+      label_classes << "hidden" if icon_only
+      plugin = 'redmine_scheduling_poll'
+      sprite_icon(icon_name, size: size, css_class: css_class, plugin: plugin) + content_tag(:span, label_text, class: label_classes.join(' '))
+    end
+  end
+
 end

--- a/app/models/scheduling_poll.rb
+++ b/app/models/scheduling_poll.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SchedulingPoll < ActiveRecord::Base
-  unloadable
+  unloadable if respond_to?(:unloadable)
 
   belongs_to :issue
   has_many :scheduling_poll_items, :dependent => :destroy

--- a/app/models/scheduling_poll.rb
+++ b/app/models/scheduling_poll.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class SchedulingPoll < ActiveRecord::Base
+class SchedulingPoll < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   unloadable if respond_to?(:unloadable)
 
   belongs_to :issue

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SchedulingPollItem < ActiveRecord::Base
-  unloadable
+  unloadable if respond_to?(:unloadable)
 
   belongs_to :scheduling_poll
   has_many :scheduling_votes, :dependent => :destroy

--- a/app/models/scheduling_poll_item.rb
+++ b/app/models/scheduling_poll_item.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class SchedulingPollItem < ActiveRecord::Base
+class SchedulingPollItem < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   unloadable if respond_to?(:unloadable)
 
   belongs_to :scheduling_poll

--- a/app/models/scheduling_vote.rb
+++ b/app/models/scheduling_vote.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class SchedulingVote < ActiveRecord::Base
+class SchedulingVote < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base)
   unloadable if respond_to?(:unloadable)
 
   belongs_to :user

--- a/app/models/scheduling_vote.rb
+++ b/app/models/scheduling_vote.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class SchedulingVote < ActiveRecord::Base
-  unloadable
+  unloadable if respond_to?(:unloadable)
 
   belongs_to :user
   belongs_to :scheduling_poll_item

--- a/app/views/scheduling_polls/_form.html.erb
+++ b/app/views/scheduling_polls/_form.html.erb
@@ -22,7 +22,7 @@
   <tfoot>
   <tr>
   <td colspan="3">
-    <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+    <% if defined? scheduling_icon_with_label %><%# redmine >= 6.0 %>
       <%= link_to_function(scheduling_icon_with_label('add', l(:label_add_scheduling_poll_item)),
                            "scheduling_polls_add_item(\"#{escape_javascript(add_item_tmpl)}\")",
                            :class => 'icon icon-add', :id => 'scheduling_poll_add_item_link') %>
@@ -39,6 +39,7 @@
   <%= f.submit l(:label_update_scheduling_poll_items) %>
 </div>
 
+<% include_calendar_headers_tags %>
 <%= javascript_tag <<EOD
 function scheduling_polls_update_date_picker(enable) {
   "use strict";
@@ -48,13 +49,10 @@ function scheduling_polls_update_date_picker(enable) {
     enable = ($("form .ui-datepicker-trigger").length > 0)? false : true;
   }
   if (enable) {
-    $("form .scheduling_poll_item_text:not([disabled]):not([readonly])").datepicker({
+    $("form .scheduling_poll_item_text:not([disabled]):not([readonly])").datepicker($.extend(datepickerOptions, {
       dateFormat: '#{Setting.plugin_redmine_scheduling_poll["scheduling_poll_item_date_format"]}',
-      buttonImage: '#{asset_path('calendar.png')}', // TODO // redmine < 7.0
-      showOn: 'button', buttonImageOnly: true,
-      showButtonPanel: true, showWeek: true, showOtherMonths: true,
-      selectOtherMonths: true, changeMonth: true, changeYear: true
-    });
+      showOn: 'button', buttonImageOnly: true
+    }));
   } else {
     $("form .scheduling_poll_item_text").datepicker("destroy");
   }

--- a/app/views/scheduling_polls/_form.html.erb
+++ b/app/views/scheduling_polls/_form.html.erb
@@ -22,7 +22,13 @@
   <tfoot>
   <tr>
   <td colspan="3">
-    <%= link_to_function l(:label_add_scheduling_poll_item), "scheduling_polls_add_item(\"#{escape_javascript(add_item_tmpl)}\")", :class => 'icon icon-add', :id => 'scheduling_poll_add_item_link' %>
+    <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+      <%= link_to_function(scheduling_icon_with_label('add', l(:label_add_scheduling_poll_item)),
+                           "scheduling_polls_add_item(\"#{escape_javascript(add_item_tmpl)}\")",
+                           :class => 'icon icon-add', :id => 'scheduling_poll_add_item_link') %>
+    <% else %>
+      <%= link_to_function l(:label_add_scheduling_poll_item), "scheduling_polls_add_item(\"#{escape_javascript(add_item_tmpl)}\")", :class => 'icon icon-add', :id => 'scheduling_poll_add_item_link' %>
+    <% end %>
   </td>
   </tr>
   </tfoot>
@@ -44,8 +50,8 @@ function scheduling_polls_update_date_picker(enable) {
   if (enable) {
     $("form .scheduling_poll_item_text:not([disabled]):not([readonly])").datepicker({
       dateFormat: '#{Setting.plugin_redmine_scheduling_poll["scheduling_poll_item_date_format"]}',
+      buttonImage: '#{asset_path('calendar.png')}', // TODO // redmine < 7.0
       showOn: 'button', buttonImageOnly: true,
-      buttonImage: '#{path_to_image('/images/calendar.png')}',
       showButtonPanel: true, showWeek: true, showOtherMonths: true,
       selectOtherMonths: true, changeMonth: true, changeYear: true
     });

--- a/app/views/scheduling_polls/_scheduling_poll_item_form.html.erb
+++ b/app/views/scheduling_polls/_scheduling_poll_item_form.html.erb
@@ -9,13 +9,28 @@
   <%= f_item.hidden_field :position, :value => f_item.index %>
 </td>
 <td class="reorder">
-  <%= link_to_function image_tag('2uparrow.png',   :alt => l(:label_sort_highest), :plugin => 'redmine_scheduling_poll'),
-    "scheduling_poll_move_item_position(-2, #{f_item.index})", :title => l(:label_sort_highest) %>
-  <%= link_to_function image_tag('1uparrow.png',   :alt => l(:label_sort_higher), :plugin => 'redmine_scheduling_poll'),
-    "scheduling_poll_move_item_position(-1, #{f_item.index})", :title => l(:label_sort_higher) %>
-  <%= link_to_function image_tag('1downarrow.png', :alt => l(:label_sort_lower), :plugin => 'redmine_scheduling_poll'),
-    "scheduling_poll_move_item_position(+1, #{f_item.index})", :title => l(:label_sort_lower) %>
-  <%= link_to_function image_tag('2downarrow.png', :alt => l(:label_sort_lowest), :plugin => 'redmine_scheduling_poll'),
-    "scheduling_poll_move_item_position(+2, #{f_item.index})", :title => l(:label_sort_lowest) %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+    <%= link_to_function(scheduling_icon_with_label('arrows-up', l(:label_sort_highest)),
+                         "scheduling_poll_move_item_position(-2, #{f_item.index})", :title => l(:label_sort_highest),
+                         :class => 'icon-only icon-arrows-up') %>
+    <%= link_to_function(scheduling_icon_with_label('arrow-up', l(:label_sort_higher)),
+                         "scheduling_poll_move_item_position(-1, #{f_item.index})", :title => l(:label_sort_higher),
+                         :class => 'icon-only icon-arrow-up') %>
+    <%= link_to_function(scheduling_icon_with_label('arrow-down', l(:label_sort_lower)),
+                         "scheduling_poll_move_item_position(+1, #{f_item.index})", :title => l(:label_sort_lower),
+                         :class => 'icon-only icon-arrow-down') %>
+    <%= link_to_function(scheduling_icon_with_label('arrows-down', l(:label_sort_lowest)),
+                         "scheduling_poll_move_item_position(+2, #{f_item.index})", :title => l(:label_sort_lowest),
+                         :class => 'icon-only icon-arrows-down') %>
+  <% else %>
+    <%= link_to_function image_tag('2uparrow.png',   :alt => l(:label_sort_highest), :plugin => 'redmine_scheduling_poll'),
+      "scheduling_poll_move_item_position(-2, #{f_item.index})", :title => l(:label_sort_highest) %>
+    <%= link_to_function image_tag('1uparrow.png',   :alt => l(:label_sort_higher), :plugin => 'redmine_scheduling_poll'),
+      "scheduling_poll_move_item_position(-1, #{f_item.index})", :title => l(:label_sort_higher) %>
+    <%= link_to_function image_tag('1downarrow.png', :alt => l(:label_sort_lower), :plugin => 'redmine_scheduling_poll'),
+      "scheduling_poll_move_item_position(+1, #{f_item.index})", :title => l(:label_sort_lower) %>
+    <%= link_to_function image_tag('2downarrow.png', :alt => l(:label_sort_lowest), :plugin => 'redmine_scheduling_poll'),
+      "scheduling_poll_move_item_position(+2, #{f_item.index})", :title => l(:label_sort_lowest) %>
+  <% end %>
 </td>
 </tr>

--- a/app/views/scheduling_polls/_scheduling_poll_item_form.html.erb
+++ b/app/views/scheduling_polls/_scheduling_poll_item_form.html.erb
@@ -9,7 +9,7 @@
   <%= f_item.hidden_field :position, :value => f_item.index %>
 </td>
 <td class="reorder">
-  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 6.0 %>
     <%= link_to_function(scheduling_icon_with_label('arrows-up', l(:label_sort_highest)),
                          "scheduling_poll_move_item_position(-2, #{f_item.index})", :title => l(:label_sort_highest),
                          :class => 'icon-only icon-arrows-up') %>

--- a/app/views/scheduling_polls/show.html.erb
+++ b/app/views/scheduling_polls/show.html.erb
@@ -11,7 +11,12 @@
 
 <div id="scheduling-poll" class="box">
 <div class="contextual">
-  <%= link_to l(:label_edit_scheduling_poll_items), scheduling_poll_edit_url(@poll), :class => 'icon icon-edit' %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+    <%= link_to(scheduling_icon_with_label('edit', l(:label_edit_scheduling_poll_items)),
+                scheduling_poll_edit_url(@poll), :class => 'icon icon-edit') %>
+  <% else %>
+    <%= link_to l(:label_edit_scheduling_poll_items), scheduling_poll_edit_url(@poll), :class => 'icon icon-edit' %>
+  <% end %>
 </div>
 <h3><%= @poll.issue.subject %></h3>
 
@@ -59,7 +64,12 @@
 </div>
 <% if User.current.allowed_to?(:vote_schduling_polls, @poll.issue.project) %>
 <div>
-  <%= link_to_function l(:label_add_comment_with_scheduling_poll_vote), '$("#vote_comment_fields").show();$(this).hide()', :class => 'icon icon-comment' %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+    <%= link_to_function(scheduling_icon_with_label('comment', l(:label_add_comment_with_scheduling_poll_vote)),
+                         '$("#vote_comment_fields").show();$(this).hide()', :class => 'icon icon-comment') %>
+  <% else %>
+    <%= link_to_function l(:label_add_comment_with_scheduling_poll_vote), '$("#vote_comment_fields").show();$(this).hide()', :class => 'icon icon-comment' %>
+  <% end %>
   <div id="vote_comment_fields" style="display: none;">
     <%= text_area_tag :vote_comment, '', :class => 'wiki-edit' %>
     <% if Redmine::VERSION::MAJOR >= 4 %><%# redmine >= 4.0 %>

--- a/app/views/scheduling_polls/show.html.erb
+++ b/app/views/scheduling_polls/show.html.erb
@@ -11,7 +11,7 @@
 
 <div id="scheduling-poll" class="box">
 <div class="contextual">
-  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 6.0 %>
     <%= link_to(scheduling_icon_with_label('edit', l(:label_edit_scheduling_poll_items)),
                 scheduling_poll_edit_url(@poll), :class => 'icon icon-edit') %>
   <% else %>
@@ -64,7 +64,7 @@
 </div>
 <% if User.current.allowed_to?(:vote_schduling_polls, @poll.issue.project) %>
 <div>
-  <% if defined? scheduling_icon_with_label %><%# redmine >= 7.0 %>
+  <% if defined? scheduling_icon_with_label %><%# redmine >= 6.0 %>
     <%= link_to_function(scheduling_icon_with_label('comment', l(:label_add_comment_with_scheduling_poll_vote)),
                          '$("#vote_comment_fields").show();$(this).hide()', :class => 'icon icon-comment') %>
   <% else %>

--- a/assets/images/icons.svg
+++ b/assets/images/icons.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" class="icon--sprite">
+  <defs>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--add">
+      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0"/>
+      <path d="M9 12h6"/>
+      <path d="M12 9v6"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--arrow-down">
+      <path d="M12 5l0 14"/>
+      <path d="M18 13l-6 6"/>
+      <path d="M6 13l6 6"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--arrow-up">
+      <path d="M12 5l0 14"/>
+      <path d="M18 11l-6 -6"/>
+      <path d="M6 11l6 -6"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--arrows-down">
+      <path d="M7 21l0 -18"/>
+      <path d="M20 18l-3 3l-3 -3"/>
+      <path d="M4 18l3 3l3 -3"/>
+      <path d="M17 21l0 -18"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--arrows-up">
+      <path d="M17 3l0 18"/>
+      <path d="M4 6l3 -3l3 3"/>
+      <path d="M20 6l-3 -3l-3 3"/>
+      <path d="M7 3l0 18"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--comment">
+      <path d="M8 9h8"/>
+      <path d="M8 13h6"/>
+      <path d="M18 4a3 3 0 0 1 3 3v8a3 3 0 0 1 -3 3h-5l-5 3v-3h-2a3 3 0 0 1 -3 -3v-8a3 3 0 0 1 3 -3h12z"/>
+    </symbol>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--edit">
+      <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1"/>
+      <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z"/>
+      <path d="M16 5l3 3"/>
+    </symbol>
+  </defs>
+</svg>

--- a/config/icon_source.yml
+++ b/config/icon_source.yml
@@ -1,0 +1,14 @@
+- name: add
+  svg: circle-plus
+- name: edit
+  svg: edit
+- name: comment
+  svg: message
+- name: arrows-up
+  svg: arrows-up
+- name: arrow-up
+  svg: arrow-up
+- name: arrow-down
+  svg: arrow-down
+- name: arrows-down
+  svg: arrows-down

--- a/init.rb
+++ b/init.rb
@@ -2,12 +2,12 @@ require 'redmine'
 require File.expand_path('../lib/redmine_scheduling_poll/hooks', __FILE__)
 
 Redmine::Plugin.register :redmine_scheduling_poll do
-  requires_redmine :version_or_higher => '4.0.0'
+  requires_redmine :version_or_higher => '4.2.0'
 
   name 'Scheduling Poll plugin'
   author '@cat_in_136'
   description 'provide simple polls to scheduling appointments'
-  version '5.0.0'
+  version '6.0.0'
   url 'https://github.com/cat-in-136/redmine_scheduling_poll'
   author_url 'https://github.com/cat-in-136/'
 

--- a/test/fixtures/scheduling_polls.yml
+++ b/test/fixtures/scheduling_polls.yml
@@ -2,8 +2,8 @@
 schduling_polls_001:
   id: 1
   issue_id: 1
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 schduling_polls_002:
   id: 2
   issue_id: 2
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>

--- a/test/fixtures/scheduling_votes.yml
+++ b/test/fixtures/scheduling_votes.yml
@@ -4,40 +4,40 @@ scheduling_vote_001:
   user_id: 1
   scheduling_poll_item_id: 1
   value: 3
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_002:
   id: 2
   user_id: 1
   scheduling_poll_item_id: 2
   value: 3
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_003:
   id: 3
   user_id: 1
   scheduling_poll_item_id: 3
   value: 3
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_004:
   id: 4
   user_id: 2
   scheduling_poll_item_id: 1
   value: 2
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_005:
   id: 5
   user_id: 2
   scheduling_poll_item_id: 2
   value: 3
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_006:
   id: 6
   user_id: 2
   scheduling_poll_item_id: 3
   value: 4
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>
 scheduling_vote_007:
   id: 7
   user_id: 3
   scheduling_poll_item_id: 1
   value: 1
-  created_at: <%= 1.minute.ago.to_s(:db) %>
+  created_at: <%= 1.minute.ago %>


### PR DESCRIPTION
1. **Update Redmine/Ruby Versions in Workflows**:
   - Updated the Redmine/Redmica/Ruby versions in the GitHub workflows to the latest stable releases.
   - Added new matrix environments for testing.

2. **Ignore `unloadable` if Method Missing**:
   - Modified the `unloadable` declaration in several models and controllers to conditionally check if the method is defined.

3. **Use `ApplicationRecord` Instead of `ActiveRecord::Base`**:
   - Refactored models to inherit from `ApplicationRecord` if available, ensuring compatibility with Rails7.

4. **Workaround for LoadError**:
   - Added a workaround in the GitHub workflow to handle the `LoadError: cannot load such file -- blankslate` issue for older versions.

5. **Drop Support for Redmine 4.0 and 4.1**:
   - Removed references and support for Redmine versions 4.0 and 4.1 from the workflows.

6. **Update DateTime Handling**:
   - Changed the way `DateTime` is formatted in fixtures to comply with Rails 7 standards.

7. **Introduce Tabler Icons for Redmine 6.0**:
   - Added new SVG icons and updated views to utilize the new icon set, matching redmine6 user interface.

8. **Update README and init.rb**:
    - Specified licenses in the README and updated the Redmine version requirement to 4.2.0. The plugin version has been bumped to 6.0.0.
