### PR TITLE
Update Redmine versions in GitHub Actions workflow to resolve ActiveSupport::LoggerThreadSafeLevel::Logger error

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,17 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
-        - '3.3 redmica/redmica@v3.1.0'
+        - '3.3 redmica/redmica@v3.1.3'
         - '3.3 redmica/redmica@v3.0.4'
-        - '3.2 redmica/redmica@v2.4.2'
-        - '3.2 redmica/redmica@v2.3.2'
-        - '3.1 redmica/redmica@v2.2.3'
-        - '3.0 redmica/redmica@v2.2.3'
-        - '2.7 redmica/redmica@v2.2.3'
-        - '3.3 redmine/redmine@6.0.1'
-        - '3.2 redmine/redmine@5.1.4'
-        - '3.1 redmine/redmine@5.0.10'
-        - '3.0 redmine/redmine@5.0.10'
+        - '3.3 redmine/redmine@6.0.3'
+        - '3.2 redmine/redmine@5.1.6'
+        - '3.1 redmine/redmine@5.0.11'
+        - '3.0 redmine/redmine@5.0.11'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
         experimental: [false]


### PR DESCRIPTION
This PR updates the GitHub Actions workflow by dropping support for outdated Ruby versions (2.7 to 3.2) and upgrading Redmine dependencies. This change resolves the dependency error `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`.

- **Workflow Updates:**
  - Removed Redmica support for Ruby versions 2.7 through 3.2.
  - Updated Redmica to version `v3.1.3`.
  - Upgraded Redmine versions to:
    - `6.0.3`
    - `5.1.6`
    - `5.0.11`